### PR TITLE
Add UserProfileUrl to ApplicationDTO and update mappings

### DIFF
--- a/P2PDelivery.Application/DTOs/ApplicationDTOs/ApplicationDTO.cs
+++ b/P2PDelivery.Application/DTOs/ApplicationDTOs/ApplicationDTO.cs
@@ -10,5 +10,7 @@ public class ApplicationDTO
     public string ApplicationStatus { get; set; }
     public int UserId { get; set; }
     public string UserName { get; set; }
+    public string UserProfileUrl { get; set; }
+
 
 }

--- a/P2PDelivery.Application/MappingProfiles/DRApplicationProfile.cs
+++ b/P2PDelivery.Application/MappingProfiles/DRApplicationProfile.cs
@@ -16,7 +16,9 @@ namespace P2PDelivery.Application.MappingProfiles
             CreateMap<AddApplicationDTO, DRApplication>();
 
             CreateMap<ApplicationDTO, DRApplication>().ReverseMap()
-                .ForMember( dst=> dst.UserName, opt=> opt.MapFrom(src=>src.User.FullName));
+                .ForMember( dst=> dst.UserName, opt=> opt.MapFrom(src=>src.User.FullName))
+                .ForMember( dst=> dst.UserProfileUrl, opt=> opt.MapFrom(src=>src.User.ProfileImageUrl))
+                ;
         }
     }
 }

--- a/P2PDelivery.Application/Services/DeliveryRequestService.cs
+++ b/P2PDelivery.Application/Services/DeliveryRequestService.cs
@@ -28,6 +28,8 @@ namespace P2PDelivery.Application.Services
         public async Task<RequestResponse<DeliveryRequestDTO>> CreateDeliveryRequestAsync(CreateDeliveryRequestDTO dto)
         {
             var entity=_mapper.Map<DeliveryRequest>(dto);
+            entity.Status = DeliveryRequestStatus.Pending;
+
             // Handle image saving
             if (dto.DRImage != null && dto.DRImage.Length > 0)
             {


### PR DESCRIPTION
- Introduced `UserProfileUrl` property in `ApplicationDTO` to store the user's profile image URL.
- Updated mapping in `DRApplicationProfile.cs` to include `UserProfileUrl` from `src.User.ProfileImageUrl`.
- Set the `Status` of `DeliveryRequest` to `Pending` upon creation in `DeliveryRequestService.cs`.